### PR TITLE
Remove read code section from homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -87,17 +87,6 @@ const Home: NextPage = () => {
             </div>
           </h4>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-1 md:gap-8">
-            <Link
-              className="flex max-w-xs flex-col gap-4 rounded-xl bg-white/10 p-4 text-white hover:bg-white/20"
-              href="https://github.com/aganswers/uiuc-chat-frontend"
-              target="_blank"
-            >
-              <h3 className="text-2xl font-bold">Read the code →</h3>
-              <div className="text-lg">
-                100% free<br></br>100% open source &#40;MIT License&#41;
-                <br></br>100% awesome
-              </div>
-            </Link>
             {/* <Link
               className="flex max-w-xs flex-col gap-4 rounded-xl bg-white/10 p-4 text-white hover:bg-white/20"
               href="https://ai.ncsa.illinois.edu/"


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove the "Read the code" section from the landing page to disable the GitHub link.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change was urgently requested as a recent LinkedIn article mention was directing new visitors from the AgAnswers.ai home page directly to the code repository, which was not the desired user experience.

---

[Open in Web](https://cursor.com/agents?id=bc-8a6e2c7e-8a21-4cc0-aae0-540cae1c1772) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-8a6e2c7e-8a21-4cc0-aae0-540cae1c1772) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)